### PR TITLE
chore: add dependabot for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary
- Add Dependabot for the `github-actions` ecosystem (weekly)
- Covers the non-reusable `actionsforge/actions-repo-spotlight` pin in `repo-spotlight.yml`

## Test plan
- [ ] Hygiene workflows (`commitmsg-conform`, `markdown-lint`) pass on the PR
- [ ] After merge, Dependabot opens PRs when the spotlight action is updated